### PR TITLE
The redeem API checks to make sure that the email address matches the…

### DIFF
--- a/Turnstile/Turnstile.Web/Controllers/TurnstileController.cs
+++ b/Turnstile/Turnstile.Web/Controllers/TurnstileController.cs
@@ -227,6 +227,8 @@ namespace Turnstile.Web.Controllers
                 if (seat != null)
                 {
                     // User has a seat reserved by their email.
+                    
+                    user.Email = userEmail; // A user might have more than one email address so we need to provide the one to the API that the seat is reserved under.
 
                     return await TryRedeemSeat(subscription, user, seat!);
                 }


### PR DESCRIPTION
… reservation. So, when we find a seat reserved under a given email, we need to set the Email property appropriately on the user before the Redeem API is called. Otherwise, the Redeem API will reject the request.